### PR TITLE
Add IPRESTRICT_TRUST_ALL_PROXIES flag

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -196,3 +196,14 @@ Default: ``[]`` (Empty List)
 Use this setting when your app is hosted behind a reverse proxy. When
 values are provided, they will be checked against the HTTP
 ``X-Forwarded-For`` header to determine the true client IP address.
+
+
+IPRESTRICT_TRUST_ALL_PROXIES
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default: ``False``
+
+Use this setting when using a managed proxy with a dynamic IP (like when
+behind an AWS Load Balancer, or other cloud equivalent). When this
+setting is ``True``, Django IP Restrict will always check the HTTP
+``X-Forwarded-For`` header to determine the true client IP address.

--- a/iprestrict/middleware.py
+++ b/iprestrict/middleware.py
@@ -30,6 +30,7 @@ class IPRestrictMiddleware(MiddlewareMixin):
         self.trusted_proxies = tuple(get_setting('IPRESTRICT_TRUSTED_PROXIES', 'TRUSTED_PROXIES', []))
         self.reload_rules = get_reload_rules_setting()
         self.ignore_proxy_header = bool(get_setting('IPRESTRICT_IGNORE_PROXY_HEADER', 'IGNORE_PROXY_HEADER', False))
+        self.trust_all_proxies = bool(get_setting('IPRESTRICT_TRUST_ALL_PROXIES', 'TRUST_ALL_PROXIES', False))
 
     def process_request(self, request):
         if self.reload_rules:
@@ -51,7 +52,7 @@ class IPRestrictMiddleware(MiddlewareMixin):
                 client_ip = forwarded_for.pop(0)
                 proxies = [closest_proxy] + forwarded_for
                 for proxy in proxies:
-                    if proxy not in self.trusted_proxies:
+                    if not self.trust_all_proxies and proxy not in self.trusted_proxies:
                         logger.warn("Client IP %s forwarded by untrusted proxy %s" % (client_ip, proxy))
                         raise exceptions.PermissionDenied
         return client_ip

--- a/iprestrict/middleware.py
+++ b/iprestrict/middleware.py
@@ -50,9 +50,11 @@ class IPRestrictMiddleware(MiddlewareMixin):
             if forwarded_for:
                 closest_proxy = client_ip
                 client_ip = forwarded_for.pop(0)
+                if self.trust_all_proxies:
+                    return client_ip
                 proxies = [closest_proxy] + forwarded_for
                 for proxy in proxies:
-                    if not self.trust_all_proxies and proxy not in self.trusted_proxies:
+                    if proxy not in self.trusted_proxies:
                         logger.warn("Client IP %s forwarded by untrusted proxy %s" % (client_ip, proxy))
                         raise exceptions.PermissionDenied
         return client_ip

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -143,3 +143,12 @@ class MiddlewareExtractClientIpTest(TestCase):
         client_ip = self.middleware.extract_client_ip(request)
         self.assertEquals(client_ip, LOCAL_IP)
 
+    @override_settings(IPRESTRICT_TRUSTED_PROXIES=(PROXY,), IPRESTRICT_TRUST_ALL_PROXIES=True)
+    def test_trust_all_proxies_on(self):
+        self.middleware = IPRestrictMiddleware()
+        proxies = ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4']
+        request = self.factory.get('', REMOTE_ADDR=PROXY,
+           HTTP_X_FORWARDED_FOR = ', '.join([LOCAL_IP] + proxies))
+
+        client_ip = self.middleware.extract_client_ip(request)
+        self.assertEquals(client_ip, LOCAL_IP)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -86,7 +86,7 @@ class ReloadRulesTest(TestCase):
 
     def test_reload_with_custom_command(self):
         from django.core.management import call_command
-        call_command('reloadrules', verbosity=0)
+        call_command('reload_rules', verbosity=0)
 
         response = self.client.get('', REMOTE_ADDR = LOCAL_IP)
         self.assertEqual(response.status_code, 404)

--- a/tests/test_reloading.py
+++ b/tests/test_reloading.py
@@ -45,4 +45,4 @@ class ReloadByViewTest(TestCase):
 
 class ReloadByCommand(ReloadByViewTest):
     def reload_rules(self):
-        call_command('reloadrules')
+        call_command('reload_rules')


### PR DESCRIPTION
Addresses #39 and passes `./runtests.sh` and `tox`.

Also fixes deprecation in tests from [renaming commands to have underscores](https://github.com/muccg/django-iprestrict/commit/a625f80351bab14a84764e8663b25d6ac9aaa407)