### PR TITLE
Code changes for django 2.0 compatibility

### DIFF
--- a/iprestrict/decorators.py
+++ b/iprestrict/decorators.py
@@ -23,7 +23,7 @@ def superuser_required(view_func):
             # The user is valid. Continue to the admin page.
             return view_func(request, *args, **kwargs)
 
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             return HttpResponseForbidden('Forbidden!')
 
         assert hasattr(request, 'session'), ("The Django admin requires session middleware to be installed. "

--- a/iprestrict/migrations/0001_initial.py
+++ b/iprestrict/migrations/0001_initial.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                 ('first_ip', models.GenericIPAddressField()),
                 ('cidr_prefix_length', models.PositiveSmallIntegerField(null=True, blank=True)),
                 ('last_ip', models.GenericIPAddressField(null=True, blank=True)),
-                ('ip_group', models.ForeignKey(to='iprestrict.IPGroup')),
+                ('ip_group', models.ForeignKey(to='iprestrict.IPGroup', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'IP Range',
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
                 ('url_pattern', models.CharField(max_length=500)),
                 ('action', models.CharField(default=b'D', max_length=1, choices=[(b'A', b'ALLOW'), (b'D', b'DENY')])),
                 ('rank', models.IntegerField(blank=True)),
-                ('ip_group', models.ForeignKey(default=1, to='iprestrict.IPGroup')),
+                ('ip_group', models.ForeignKey(default=1, to='iprestrict.IPGroup', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ['rank', 'id'],

--- a/iprestrict/migrations/0003_add_ipgroup_types.py
+++ b/iprestrict/migrations/0003_add_ipgroup_types.py
@@ -33,6 +33,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='ipgroup',
             name='type',
-            field=models.CharField(default=b'range', max_length=10, choices=[(b'location', b'location based'), (b'range', b'range based')]),
+            field=models.CharField(default='range', max_length=10, choices=[('location', 'location based'), ('range', 'range based')]),
         ),
     ]

--- a/iprestrict/migrations/0004_add_iplocation.py
+++ b/iprestrict/migrations/0004_add_iplocation.py
@@ -32,11 +32,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='ipgroup',
             name='type',
-            field=models.CharField(default=b'range', max_length=10, choices=[(b'location', b'Location based'), (b'range', b'Range based')]),
+            field=models.CharField(default=b'range', max_length=10, choices=[('location', 'Location based'), ('range', 'Range based')]),
         ),
         migrations.AddField(
             model_name='iplocation',
             name='ip_group',
-            field=models.ForeignKey(to='iprestrict.IPGroup'),
+            field=models.ForeignKey(to='iprestrict.IPGroup', on_delete=models.CASCADE),
         ),
     ]

--- a/iprestrict/models.py
+++ b/iprestrict/models.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import re
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.utils import timezone
 from . import ip_utils as ipu
@@ -124,7 +124,7 @@ class IPRange(models.Model):
     class Meta:
         verbose_name = "IP Range"
 
-    ip_group = models.ForeignKey(IPGroup)
+    ip_group = models.ForeignKey(IPGroup, on_delete=models.CASCADE)
     first_ip = models.GenericIPAddressField()
     cidr_prefix_length = models.PositiveSmallIntegerField(null=True, blank=True)
     last_ip = models.GenericIPAddressField(null=True, blank=True)
@@ -173,7 +173,7 @@ class IPLocation(models.Model):
     class Meta:
         verbose_name = "IP Location"
 
-    ip_group = models.ForeignKey(IPGroup)
+    ip_group = models.ForeignKey(IPGroup, on_delete=models.CASCADE)
     country_codes = models.CharField(max_length=2000, help_text='Comma-separated list of 2 character country codes')
 
     def __contains__(self, country_code):
@@ -195,7 +195,7 @@ class Rule(models.Model):
     )
 
     url_pattern = models.CharField(max_length=500)
-    ip_group = models.ForeignKey(IPGroup, default=1)
+    ip_group = models.ForeignKey(IPGroup, default=1, on_delete=models.CASCADE)
     reverse_ip_group = models.BooleanField(default=False)
     action = models.CharField(max_length=1, choices=ACTION_CHOICES, default='D')
     rank = models.IntegerField(blank=True)

--- a/iprestrict/views.py
+++ b/iprestrict/views.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import validate_ipv46_address
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render_to_response

--- a/requirements-2.x.txt
+++ b/requirements-2.x.txt
@@ -1,0 +1,2 @@
+-r common-requirements.txt
+Django>=2.0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -32,16 +32,15 @@ INSTALLED_APPS = (
     'iprestrict',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'iprestrict.middleware.IPRestrictMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
+    'django.middleware.security.SecurityMiddleware'
 )
 
 ROOT_URLCONF = 'tests.test_urls'

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -10,7 +10,8 @@ import iprestrict.urls
 
 admin.autodiscover()
 
+app_name = "iprestrict"
 urlpatterns = [
-    url(r'^iprestrict/', include(iprestrict.urls.urlpatterns, namespace='iprestrict')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^iprestrict/', include('iprestrict.urls', namespace='iprestrict')),
+    url(r'^admin/', admin.site.urls),
 ] + staticfiles_urlpatterns()


### PR DESCRIPTION
(Remaking this PR directly off master)

I've made some minor tweaks (branched off of master) to get this middleware compatible with Django 2.x. All tests pass. Any chance this could be merged in and a version bump published to pip? I'd be happy to make reasonable changes if requested.

Note that I removed all bytes fields. Tests ran into some problems which I traced all the way to django.db.models.query.ModelIterable within the query engine, which was de-serializing the b' prefix into the actual value. I noticed some apparent inconsistent use anyway in the IPRestrict source, in the declaration of TYPE_LOCATION and TYPE_RANGE in django-iprestrict/iprestrict/models.py. It seemed prudent to just use plain strings, as this data is not that large, and the Django API docs always use string types in supporting examples.