### PR TITLE
Filter out bad forwarded IP address from Herkou.

### DIFF
--- a/iprestrict/middleware.py
+++ b/iprestrict/middleware.py
@@ -62,7 +62,8 @@ class IPRestrictMiddleware(MiddlewareMixin):
     def get_forwarded_for(self, request):
         hdr = request.META.get('HTTP_X_FORWARDED_FOR')
         if hdr is not None:
-            return [ip.strip() for ip in hdr.split(',')]
+            # Exclude unknown which sometimes precedes an IP in Heroku.
+            return [ip.strip() for ip in hdr.split(',') if ip != 'unknown']
         else:
             return []
 


### PR DESCRIPTION
Works around https://github.com/muccg/django-iprestrict/issues/53

I would invite a more general fix to check for non-IPs during the `is_restricted` section, but I chose to avoid extracting this "ip" content from the beginning because I wasn't exactly sure of what constraints to apply there.