### PR TITLE
Adding support for django 3

### DIFF
--- a/iprestrict/templates/iprestrict/test_rules.html
+++ b/iprestrict/templates/iprestrict/test_rules.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!doctype html>
 <html>
 <head>

--- a/iprestrict/views.py
+++ b/iprestrict/views.py
@@ -6,7 +6,7 @@ import json
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv46_address
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 
 try:
     from django.urls import reverse
@@ -40,7 +40,7 @@ def reload_rules(request):
 
 @superuser_required
 def test_rules_page(request):
-    return render_to_response('iprestrict/test_rules.html')
+    return render(request, 'iprestrict/test_rules.html')
 
 
 @superuser_required

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     {py27,py34,py35,py36}-django-{18,19,110,111}
     {py34,py35,py36,py37}-django-20
-    {py35,py36,py37}-django-21
+    {py35,py36,py37}-django-{21,22,30}
     flake8
 skip_missing_interpreters = True
 
@@ -22,6 +22,8 @@ deps =
     django-111: Django>=1.11,<1.12
     django-20: Django>=2.0,<2.1
     django-21: Django>=2.1,<2.2
+    django-22: Django>=2.2,<2.3
+    django-30: Django>=3.0,<3.1
 
 [testenv:flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     {py27,py34,py35,py36}-django-{18,19,110,111}
     {py34,py35,py36,py37}-django-20
-    {py35,py36,py37}-django-{21,22,30}
+    {py35,py36,py37}-django-{21,22}
+    {py36,py37,py38}-django-{30}
     flake8
 skip_missing_interpreters = True
 


### PR DESCRIPTION
Thanks for such a handy library! Here's a PR to make it compatible with Django 3.0.

- `django.shortcuts.render_to_response` was deprecated in Django 2.0, and removed in 3.0. Updating it to use its replacement, `render` got tests to pass for 3.0 (https://docs.djangoproject.com/en/3.0/releases/2.0/#features-deprecated-in-2-0)
- updated static file loading in the rule tester template, which caused an exception on Django 3 (https://docs.djangoproject.com/en/3.0/releases/2.1/#features-deprecated-in-2-1)