### PR TITLE
IPRESTRICT_IGNORE_PATHS environment variable feature

### DIFF
--- a/iprestrict/__init__.py
+++ b/iprestrict/__init__.py
@@ -5,4 +5,4 @@ from .restrictor import IPRestrictor
 
 __all__ = ["IPRestrictor"]
 
-__version__ = "1.8.1"
+__version__ = "1.8.3"

--- a/iprestrict/__init__.py
+++ b/iprestrict/__init__.py
@@ -5,4 +5,4 @@ from .restrictor import IPRestrictor
 
 __all__ = ["IPRestrictor"]
 
-__version__ = "1.8.0"
+__version__ = "1.8.0-la"

--- a/iprestrict/__init__.py
+++ b/iprestrict/__init__.py
@@ -5,4 +5,4 @@ from .restrictor import IPRestrictor
 
 __all__ = ["IPRestrictor"]
 
-__version__ = "1.8.0-la"
+__version__ = "1.8.0+la"

--- a/iprestrict/__init__.py
+++ b/iprestrict/__init__.py
@@ -5,4 +5,4 @@ from .restrictor import IPRestrictor
 
 __all__ = ["IPRestrictor"]
 
-__version__ = "1.8.0+la"
+__version__ = "1.8.1"

--- a/iprestrict/middleware.py
+++ b/iprestrict/middleware.py
@@ -7,6 +7,7 @@ import logging
 import warnings
 from .models import ReloadRulesRequest
 from .restrictor import IPRestrictor
+from django.core.exceptions import ImproperlyConfigured
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
@@ -23,6 +24,7 @@ class IPRestrictMiddleware(MiddlewareMixin):
     trusted_proxies = None
     allow_proxies = None
     reload_rules = None
+    ignore_paths = None
 
     def __init__(self, *args, **kwargs):
         super(IPRestrictMiddleware, self).__init__(*args, **kwargs)
@@ -32,6 +34,8 @@ class IPRestrictMiddleware(MiddlewareMixin):
         self.ignore_proxy_header = bool(get_setting('IPRESTRICT_IGNORE_PROXY_HEADER', 'IGNORE_PROXY_HEADER', False))
         self.trust_all_proxies = bool(get_setting('IPRESTRICT_TRUST_ALL_PROXIES', 'TRUST_ALL_PROXIES', False))
 
+        # NEW: exact paths to skip restriction check
+        self.ignore_paths = load_ignore_paths()
     def process_request(self, request):
         if self.reload_rules:
             self.reload_rules_if_needed()
@@ -39,9 +43,25 @@ class IPRestrictMiddleware(MiddlewareMixin):
         url = request.path_info
         client_ip = self.extract_client_ip(request)
 
+        # NEW: if the request path is whitelisted, skip only the restriction check
+        if self.is_ignored_path(url):
+            return
         if self.restrictor.is_restricted(url, client_ip):
             logger.warn("Denying access of %s to %s" % (url, client_ip))
             raise exceptions.PermissionDenied
+
+    def is_ignored_path(self, url):
+        if not self.ignore_paths:
+            return False
+
+        # Exact match
+        if url in self.ignore_paths:
+            return True
+
+        # Optional convenience: treat "/x" and "/x/" as equivalent
+        if url.endswith('/'):
+            return url[:-1] in self.ignore_paths
+        return (url + '/') in self.ignore_paths
 
     def extract_client_ip(self, request):
         client_ip = request.META['REMOTE_ADDR']
@@ -89,7 +109,31 @@ def get_reload_rules_setting():
 
 
 def warn_about_changed_setting(old_name, new_name):
-    # DeprecationWarnings are ignored by default, so lets make sure that
-    # the warnings are shown by using the default UserWarning instead
-    warnings.warn("The setting name '%s' has been deprecated and it will be removed in a future version. "
-                  "Please use '%s' instead." % (old_name, new_name))
+    warnings.warn(
+        "The setting name '%s' has been deprecated and it will be removed in a future version. "
+        "Please use '%s' instead." % (old_name, new_name)
+    )
+
+def load_ignore_paths():
+    """
+    NEW:
+    Setting: IPRESTRICT_IGNORE_PATHS
+    Value: list/tuple of exact request.path_info strings (e.g. "/healthz/" or "/metrics")
+    """
+    paths = get_setting('IPRESTRICT_IGNORE_PATHS', 'IGNORE_PATHS', [])
+    if not paths:
+        return set()
+
+    if not isinstance(paths, (list, tuple, set)):
+        raise ImproperlyConfigured("IPRESTRICT_IGNORE_PATHS must be a list/tuple/set of path strings")
+
+    cleaned = set()
+    for p in paths:
+        if not isinstance(p, str):
+            raise ImproperlyConfigured("IPRESTRICT_IGNORE_PATHS items must be strings; got %r" % (p,))
+        if not p.startswith('/'):
+            # enforce Django-like path shape
+            p = '/' + p
+        cleaned.add(p)
+
+    return cleaned

--- a/iprestrict/middleware.py
+++ b/iprestrict/middleware.py
@@ -37,15 +37,17 @@ class IPRestrictMiddleware(MiddlewareMixin):
         # NEW: exact paths to skip restriction check
         self.ignore_paths = load_ignore_paths()
     def process_request(self, request):
+        url = request.path_info
+
+        # NEW: if the request path is whitelisted, skip any iprestrict work (incl. reload_rules DB check)
+        if self.is_ignored_path(url):
+            return
+
         if self.reload_rules:
             self.reload_rules_if_needed()
 
-        url = request.path_info
         client_ip = self.extract_client_ip(request)
 
-        # NEW: if the request path is whitelisted, skip only the restriction check
-        if self.is_ignored_path(url):
-            return
         if self.restrictor.is_restricted(url, client_ip):
             logger.warn("Denying access of %s to %s" % (url, client_ip))
             raise exceptions.PermissionDenied

--- a/iprestrict/urls.py
+++ b/iprestrict/urls.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.conf.urls import url
+from django.urls import re_path
 from .views import test_rules_page, test_match, reload_rules
 from .views import move_rule_up, move_rule_down
 
 app_name = "iprestrict"
 urlpatterns = [
-    url(r'^$', test_rules_page),
-    url(r'^move_rule_up/(?P<rule_id>\d+)[/]?$', move_rule_up, name='move_rule_up'),
-    url(r'^move_rule_down/(?P<rule_id>\d+)[/]?$', move_rule_down, name='move_rule_down'),
-    url(r'^reload_rules[/]?$', reload_rules, name='reload_rules'),
-    url(r'^test_match[/]?$', test_match, name='test_match'),
+    re_path(r"^$", test_rules_page),
+    re_path(r"^move_rule_up/(?P<rule_id>\d+)/?$", move_rule_up, name="move_rule_up"),
+    re_path(r"^move_rule_down/(?P<rule_id>\d+)/?$", move_rule_down, name="move_rule_down"),
+    re_path(r"^reload_rules/?$", reload_rules, name="reload_rules"),
+    re_path(r"^test_match/?$", test_match, name="test_match"),
 ]


### PR DESCRIPTION
Added a feature so that users can use the IP restrict with:

IPRESTRICT_IGNORE_PATHS: "/healthz,/metrics,/etc..."

This is helpful so that those paths wont go through DB reads hence monitoring won't impact performance of DB. I have tested and this works well on my use case.

The IPRESTRICT_IGNORE_PATHS environment just need to be created by the implementor in their own projects.
